### PR TITLE
docs(fix basurl): update baseurl to support github pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://all-contributors.github.io',
-  base: '/all-contributors',
+  base: '',
   output: 'static',
 
   redirects: {


### PR DESCRIPTION
This is a quick fix now that i've renamed the repo!! it will fix all of the internal links that don't work because of the old baseurl (fixed here).

**What**:

**Why**:

**How**:

**Checklist**:
- [x] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table. <!-- this is optional, see the contributing guidelines for instructions -->
[Bot Usage](https://allcontributors.org/docs/en/bot/installation#4-update-your-contributing-documentation)

<!-- feel free to add additional comments -->
